### PR TITLE
[LOG4J2-1127] log4j2.xml cannot be parsed on Oracle Weblogic 12c

### DIFF
--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/xml/XmlConfiguration.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/xml/XmlConfiguration.java
@@ -145,7 +145,7 @@ public class XmlConfiguration extends AbstractConfiguration implements Reconfigu
                 document = documentBuilder.parse(source);
             } catch (final Exception e) {
                 // LOG4J2-1127
-                if (e.getCause() instanceof UnsupportedOperationException) {
+                if (e instanceof UnsupportedOperationException) {
                     LOGGER.warn(
                             "The DocumentBuilder {} does not support an operation: {}. Trying again without XInclude...",
                             documentBuilder, e);


### PR DESCRIPTION
Small fix on the previous commit.
